### PR TITLE
Fix get expire_log_days config as int

### DIFF
--- a/twindb_backup/backup.py
+++ b/twindb_backup/backup.py
@@ -245,7 +245,7 @@ def backup_binlogs(run_type, config):  # pylint: disable=too-many-locals
         status.add(binlog_copy)
 
     try:
-        expire_log_days = config.get('mysql', 'expire_log_days')
+        expire_log_days = config.getint('mysql', 'expire_log_days')
     except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
         expire_log_days = 7
 


### PR DESCRIPTION
Discovered bug running `twindb-backup backup hourly`, it gets a config as str instead of int type.

```
$ twindb-backup backup hourly
Traceback (most recent call last):
  File "/usr/bin/twindb-backup", line 9, in <module>
    load_entry_point('twindb-backup==2.16.1', 'console_scripts', 'twindb-backup')()
  File "/opt/twindb-backup/embedded/lib/python2.7/site-packages/click-6.7-py2.7.egg/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/opt/twindb-backup/embedded/lib/python2.7/site-packages/click-6.7-py2.7.egg/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/opt/twindb-backup/embedded/lib/python2.7/site-packages/click-6.7-py2.7.egg/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/twindb-backup/embedded/lib/python2.7/site-packages/click-6.7-py2.7.egg/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/twindb-backup/embedded/lib/python2.7/site-packages/click-6.7-py2.7.egg/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/opt/twindb-backup/embedded/lib/python2.7/site-packages/click-6.7-py2.7.egg/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/opt/twindb-backup/embedded/lib/python2.7/site-packages/click-6.7-py2.7.egg/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/opt/twindb-backup/embedded/lib/python2.7/site-packages/twindb_backup-2.16.1-py2.7.egg/twindb_backup/cli.py", line 135, in backup
    binlogs_only=binlogs_only
  File "/opt/twindb-backup/embedded/lib/python2.7/site-packages/twindb_backup-2.16.1-py2.7.egg/twindb_backup/backup.py", line 371, in run_backup_job
    backup_everything(run_type, cfg, binlogs_only=binlogs_only)
  File "/opt/twindb-backup/embedded/lib/python2.7/site-packages/twindb_backup-2.16.1-py2.7.egg/twindb_backup/backup.py", line 317, in backup_everything
    backup_binlogs(run_type, config)
  File "/opt/twindb-backup/embedded/lib/python2.7/site-packages/twindb_backup-2.16.1-py2.7.egg/twindb_backup/backup.py", line 256, in backup_binlogs
    if copy.created_at < now - expire_log_days * 24 * 3600:
TypeError: unsupported operand type(s) for -: 'int' and 'str'
```