### PR TITLE
Use caching for omnibus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,10 @@ docker-start:
 		--rm \
 		--dns 8.8.8.8 \
 		--dns 208.67.222.222 \
+		--env AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+		--env AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+		--env PLATFORM=${PLATFORM} \
+		--env OS_VERSION=${OS_VERSION} \
 		"twindb/omnibus-${PLATFORM}:backup-${OS_VERSION}" \
 		bash -l
 
@@ -189,6 +193,10 @@ package: ## Build package - PLATFORM must be one of "centos", "debian", "ubuntu"
 		--rm \
 		--dns 8.8.8.8 \
 		--dns 208.67.222.222 \
+		--env AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+		--env AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+		--env PLATFORM=${PLATFORM} \
+		--env OS_VERSION=${OS_VERSION} \
 		"twindb/omnibus-${PLATFORM}:backup-${OS_VERSION}" \
 		bash -l /twindb-backup/omnibus/omnibus_build.sh
 

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -26,20 +26,16 @@
 
 # Disable git caching
 # ------------------------------
-use_git_caching false
+use_git_caching true
 
 # Enable S3 asset caching
 # ------------------------------
-bucket = ENV['S3_OMNIBUS_BUCKET']
+bucket = 'omnibus-cache-twindb-backup'
 
-if bucket.nil? || bucket.empty?
-  use_s3_caching false
-else
-  use_s3_caching true
-  s3_access_key  ENV['AWS_ACCESS_KEY_ID']
-  s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
-  s3_bucket      ENV['AWS_S3_BUCKET']
-end
+use_s3_caching true
+s3_access_key  ENV['AWS_ACCESS_KEY_ID']
+s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
+s3_bucket      bucket
 
 # Customize compiler bits
 # ------------------------------

--- a/omnibus/omnibus_build.sh
+++ b/omnibus/omnibus_build.sh
@@ -1,5 +1,30 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -ex
+
+CACHE_REPO=${PLATFORM}-${OS_VERSION}
 
 cd /twindb-backup/omnibus
+
 bundle install --binstubs
+bin/omnibus cache populate
+
+git config --global user.email "omnibus@twindb.com"
+git config --global user.name "Omnibus Builder"
+
+mkdir -p cache
+aws s3 cp s3://omnibus-cache-twindb-backup/${CACHE_REPO} cache/ || true
+
+if test -f cache/${CACHE_REPO}; then
+    git clone --mirror \
+        cache/${CACHE_REPO} \
+        /var/cache/omnibus/cache/git_cache/opt/twindb-backup
+fi
+
 bin/omnibus build twindb-backup
+
+if ! test -f cache/${CACHE_REPO}; then
+    git --git-dir=/var/cache/omnibus/cache/git_cache/opt/twindb-backup \
+        bundle create cache/${CACHE_REPO} --tags
+    aws s3 cp cache/${CACHE_REPO} s3://omnibus-cache-twindb-backup/${CACHE_REPO}
+fi


### PR DESCRIPTION
Omnibus uses S3 to cache software source code archives and git cache for built softwares.