### PR TITLE
Fix issue #190

### DIFF
--- a/omnibus/config/projects/twindb-backup.rb
+++ b/omnibus/config/projects/twindb-backup.rb
@@ -23,7 +23,7 @@ homepage 'https://twindb.com'
 # and /opt/twindb-backup on all other platforms
 install_dir '/opt/twindb-backup'
 
-build_version '2.18.2'
+build_version '2.18.3'
 
 build_iteration 1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.18.2
+current_version = 2.18.3
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open('requirements_dev.txt') as f:
 
 setup(
     name='twindb-backup',
-    version='2.18.2',
+    version='2.18.3',
     description="TwinDB Backup tool for files, MySQL et al.",
     long_description=readme + '\n\n' + history,
     author="TwinDB Development Team",

--- a/tests/unit/backup/test_backup_binlogs.py
+++ b/tests/unit/backup/test_backup_binlogs.py
@@ -1,0 +1,36 @@
+import mock
+
+from twindb_backup.backup import backup_binlogs
+from twindb_backup.source.mysql_source import MySQLClient
+from twindb_backup.status.binlog_status import BinlogStatus
+
+
+@mock.patch.object(BinlogStatus, 'save')
+@mock.patch('twindb_backup.backup.osp')
+@mock.patch('twindb_backup.backup.binlogs_to_backup')
+@mock.patch.object(MySQLClient, 'cursor')
+def test_backup_binlogs_returns_if_no_binlogs(
+        mock_cursor,
+        mock_binlogs_to_backup,
+        mock_osp,
+        mock_save):
+
+    mock_cursor_r = mock.MagicMock()
+    mock_cursor_r.fetchone.return_value = {
+        '@@log_bin_basename': None
+    }
+
+    mock_cursor.return_value.__enter__.return_value = mock_cursor_r
+
+    backup_binlogs('foo', mock.Mock())
+    mock_binlogs_to_backup.assert_called_once_with(
+        mock_cursor_r, last_binlog=None
+    )
+    mock_cursor_r.execute.assert_has_calls(
+        [
+            mock.call('FLUSH BINARY LOGS'),
+            mock.call('SELECT @@log_bin_basename'),
+        ]
+    )
+    assert mock_osp.dirname.call_count == 0
+    assert mock_save.call_count == 0

--- a/twindb_backup/__init__.py
+++ b/twindb_backup/__init__.py
@@ -40,7 +40,7 @@ import sys
 
 __author__ = 'TwinDB Development Team'
 __email__ = 'dev@twindb.com'
-__version__ = '2.18.2'
+__version__ = '2.18.3'
 STATUS_FORMAT_VERSION = 1
 LOCK_FILE = '/var/run/twindb-backup.lock'
 LOG_FILE = '/var/log/twindb-backup-measures.log'

--- a/twindb_backup/backup.py
+++ b/twindb_backup/backup.py
@@ -224,7 +224,10 @@ def backup_binlogs(run_type, config):  # pylint: disable=too-many-locals
         )
         cur.execute("SELECT @@log_bin_basename")
         row = cur.fetchone()
-        binlog_dir = osp.dirname(row['@@log_bin_basename'])
+        if row['@@log_bin_basename']:
+            binlog_dir = osp.dirname(row['@@log_bin_basename'])
+        else:
+            return
 
     for binlog_name in backup_set:
         src = BinlogSource(run_type, mysql_client, binlog_name)


### PR DESCRIPTION
When binary logging is disabled, variable `@@log_bin_basename` is None. In that case do not backup binary logs.
Fixes #190 .