### PR TITLE
Fix for ssh destination delete

### DIFF
--- a/twindb_backup/destination/ssh.py
+++ b/twindb_backup/destination/ssh.py
@@ -90,7 +90,8 @@ class Ssh(BaseDestination):
         :param path: Path to a remote file.
         :type path: str
         """
-        cmd = "rm %s" % path
+        remote_name = osp.join(self.remote_path, path)
+        cmd = "rm %s" % remote_name
         self.execute_command(cmd)
 
     def ensure_tcp_port_listening(self, port, wait_timeout=10):


### PR DESCRIPTION
Solve issue #210 #149 #193  by joining path with remote name.

Test run against ssh destination:
```
2020-05-15 23:31:07,290: DEBUG: backup.backup_binlogs():259: Deleting copy that was taken 606643 seconds ago
2020-05-15 23:31:07,290: DEBUG: ssh.execute_command():142: Executing: rm /backup/lmyb/redacted_hostname/binlog/redacted_hostname_binlog.004849.gz
2020-05-15 23:31:07,372: DEBUG: client.execute():110: Executing command: rm /backup/lmyb/redacted_hostname/binlog/redacted_hostname_binlog.004849.gz
```
