### PR TITLE
Print docker commands in integration tests

### DIFF
--- a/omnibus/omnibus_build.sh
+++ b/omnibus/omnibus_build.sh
@@ -21,7 +21,7 @@ bundle install --binstubs
 #        /var/cache/omnibus/cache/git_cache/opt/twindb-backup
 #fi
 
-bin/omnibus build twindb-backup
+ruby bin/omnibus build twindb-backup
 
 #if ! test -f cache/${CACHE_REPO}; then
 #    git --git-dir=/var/cache/omnibus/cache/git_cache/opt/twindb-backup \

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,9 @@ bcrypt==3.2.2
     # via paramiko
 beautifulsoup4==4.11.1
     # via google
-boto3==1.24.12
+boto3==1.24.14
     # via -r requirements.in
-botocore==1.27.12
+botocore==1.27.14
     # via
     #   boto3
     #   s3transfer
@@ -36,7 +36,7 @@ charset-normalizer==2.0.12
     # via requests
 click==8.1.3
     # via -r requirements.in
-cryptography==37.0.2
+cryptography==37.0.3
     # via
     #   -r requirements.in
     #   azure-storage-blob
@@ -62,7 +62,7 @@ google-crc32c==1.3.0
     # via google-resumable-media
 google-resumable-media==2.3.3
     # via google-cloud-storage
-googleapis-common-protos==1.56.2
+googleapis-common-protos==1.56.3
     # via google-api-core
 idna==3.3
     # via requests
@@ -78,7 +78,7 @@ oauthlib==3.2.0
     # via requests-oauthlib
 paramiko==2.11.0
     # via -r requirements.in
-protobuf==3.20.1
+protobuf==4.21.1
     # via
     #   google-api-core
     #   google-cloud-storage

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -13,4 +13,5 @@ pytest ~= 7.1
 pytest-cov ~= 3.0
 pytest-timeout ~= 2.1
 python-magic == 0.4.18
+runlike ~= 1.4
 yamllint ~= 1.23

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,9 +14,9 @@ babel==2.10.3
     # via sphinx
 black==22.3.0
     # via -r requirements_dev.in
-boto3==1.24.12
+boto3==1.24.14
     # via moto
-botocore==1.27.12
+botocore==1.27.14
     # via
     #   boto3
     #   moto
@@ -32,14 +32,16 @@ cffi==1.15.0
 charset-normalizer==2.0.12
     # via requests
 click==8.1.3
-    # via black
+    # via
+    #   black
+    #   runlike
 codecov==2.1.12
     # via -r requirements_dev.in
 coverage[toml]==6.4.1
     # via
     #   codecov
     #   pytest-cov
-cryptography==37.0.2
+cryptography==37.0.3
     # via moto
 dill==0.3.5.1
     # via pylint
@@ -77,7 +79,7 @@ mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via -r requirements_dev.in
-moto==3.1.13
+moto==3.1.14
     # via -r requirements_dev.in
 mypy-extensions==0.4.3
     # via black
@@ -137,6 +139,8 @@ requests==2.28.0
     #   sphinx
 responses==0.21.0
     # via moto
+runlike==1.4.0
+    # via -r requirements_dev.in
 s3transfer==0.6.0
     # via boto3
 six==1.16.0
@@ -175,7 +179,7 @@ urllib3==1.26.9
     #   botocore
     #   requests
     #   responses
-websocket-client==1.3.2
+websocket-client==1.3.3
     # via docker
 werkzeug==2.1.2
     # via moto


### PR DESCRIPTION
`Inspector()` from can inspect a running container and generate a command that would run the container in the same configuration. Helpful for tests debugging.
