### PR TITLE
Upgrade python version for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ python:
     install:
         - requirements: "requirements.txt"
         - requirements: "requirements_dev.txt"
-    version: 3.7
+    version: "3.8"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
isort required 3.8+.
