### PR TITLE
y

### DIFF
--- a/support/bootstrap/master/centos/master1.sh
+++ b/support/bootstrap/master/centos/master1.sh
@@ -22,6 +22,7 @@ fi
 # MySQL sets random root password. Reset to empty
 systemctl stop mysqld
 rm -rf /var/lib/mysql
+mkdir /var/lib/mysql
 mysqld --initialize-insecure
 chown -R mysql:mysql /var/lib/mysql
 systemctl start mysqld


### PR DESCRIPTION
I observed strange behavior in CentOS 7 container.
`mysqld` is supposed to create `/var/lib/mysql` if starts with
`--initialize-insecure` and if it doesn't exist.
Despite runnign as root it couldn't create the directory with "Permission
denied" error. strace didn't show anything that would switch a user.
Besides, I noticed mysqld couldn't even read `/etc/my.cnf`.
I cannot explain what happens. Will try to create the directory
manually, will see how it impacts the test.
