### PR TITLE
Simplify network fixture in docker

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -5,8 +5,8 @@ __author__ = "aleks"
 
 def ensure_aws_creds():
     print("Integration tests need Amazon API credentials:")
-    print("    AWS_ACCESS_KEY_ID")
-    print("    AWS_SECRET_ACCESS_KEY")
+    print(f"    AWS_ACCESS_KEY_ID     .. {'found' if 'AWS_ACCESS_KEY_ID' in environ else 'not found'}")
+    print(f"    AWS_SECRET_ACCESS_KEY .. {'found' if 'AWS_SECRET_ACCESS_KEY' in environ else 'not found'}")
     try:
         try:
             environ["AWS_ACCESS_KEY_ID"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -156,24 +156,16 @@ def container_network(docker_client):
     network_params["subnet"] = subnet
     network_params["second_octet"] = int(subnet.split(".")[1])
 
-    try:
-        network = api.create_network(
-            name=NETWORK_NAME,
-            driver="bridge",
-            ipam=ipam_config,
-            check_duplicate=True,
-        )
-        LOG.info("Created subnet %s", network_params["subnet"])
-        LOG.debug(network)
-    except APIError as err:
-        if err.status_code == 500:
-            LOG.info("Network %r already exists", network)
-        else:
-            raise
-
+    network = api.create_network(
+        name=NETWORK_NAME,
+        driver="bridge",
+        ipam=ipam_config,
+        check_duplicate=True,
+    )
+    LOG.info("Created subnet %s", network_params["subnet"])
+    LOG.debug(network)
     yield network_params
-    if network:
-        api.remove_network(net_id=network["Id"])
+    api.remove_network(net_id=network["Id"])
 
 
 def get_container(


### PR DESCRIPTION
test_network must not exist. if it does, it must be artifact and we want
user to clean it up.
