### PR TITLE
Pin intergration test worker version to ubuntu-20.04

### DIFF
--- a/.github/workflows/intergration-tests.yml
+++ b/.github/workflows/intergration-tests.yml
@@ -19,7 +19,7 @@ on:
           - "1"
 jobs:
   test:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     env:
       AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
       AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"


### PR DESCRIPTION
Something is going on with a centos-7 images. I remember I had to
enable systemd on a centos 7 image and it looks like it doesn't work on
Ubuntu 22.04 (ubuntu-latest as of time of writing).

Normally, I'd expect something like this in a container:
```
[root@slave-2 /]# ps ax
    PID TTY      STAT   TIME COMMAND
      1 ?        Ss     0:00 /sbin/init --log-target=journal
     17 ?        Ss     0:00 /usr/lib/systemd/systemd-journald
     28 ?        Ss     0:00 /usr/lib/systemd/systemd-udevd
     52 ?        Ss     0:00 /usr/bin/dbus-daemon --system
--address=systemd: --nofork --nopidfile --systemd-activation
     58 ?        Ss     0:00 /usr/lib/systemd/systemd-logind
     97 ?        Ss     0:00 /usr/sbin/sshd -D
    132 ?        Sl     0:00 /usr/sbin/mysqld --daemonize
--pid-file=/var/run/mysqld/mysqld.pid
    181 pts/0    Ss     0:00 bash -l
    199 pts/0    R+     0:00 ps ax
```
i.e. dbus is running and ofther systemd stuff.

However on Ubuntu 22.04 I see this:

```
[root@master1-1 /]# ps x
    PID TTY      STAT   TIME COMMAND
      1 ?        Ss     0:00 /sbin/init --log-target=journal
      8 pts/0    Ss     0:00 bash -l
    171 pts/0    R+     0:00 ps x
```
