### PR TITLE
Disable apparmor on a host server before integration tests

### DIFF
--- a/.github/workflows/intergration-tests.yml
+++ b/.github/workflows/intergration-tests.yml
@@ -34,6 +34,11 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: "Disable apparmor"
+        run: |
+          sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+          sudo apparmor_parser -R /etc/apparmor.d/disable/usr.sbin.mysqld
+
       - name: "Run tests"
         run: |
           pip install -U "pip ~= 22.0.0"


### PR DESCRIPTION
The error seems to be caused by apparmor on a host machine that prevents
mysqld in a centos container to read from /etc/my.cnf.
