### PR TITLE
Tune intergration tests workflow

### DIFF
--- a/.github/workflows/intergration-tests.yml
+++ b/.github/workflows/intergration-tests.yml
@@ -6,17 +6,9 @@ on:
     inputs:
       debug_enabled:
         type: "boolean"
-        description: 'Run the build with tmate debugging enabled'
+        description: "Setup a temporary SSH access if a test fails"
         required: false
         default: false
-      pause_test:
-        type: "choice"
-        description: "if 1, the test will be paused upon error"
-        required: false
-        default: "0"
-        options:
-          - "0"
-          - "1"
 jobs:
   test:
     runs-on: "ubuntu-20.04"
@@ -49,13 +41,9 @@ jobs:
 
       - name: "Setup tmate session"
         uses: "mxschmitt/action-tmate@v3"
+        if: "${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}"
+
         with:
           limit-access-to-actor: true
-        if: >
-          ${{
-            failure()
-            && github.event_name == 'workflow_dispatch'
-            && inputs.debug_enabled
-          }}
 
 ...

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -20,7 +20,7 @@ rules:
     line-length:
         allow-non-breakable-inline-mappings: true
         allow-non-breakable-words: true
-        max: 80
+        max: 120
     new-line-at-end-of-file: "enable"
     new-lines: "enable"
     octal-values: "enable"


### PR DESCRIPTION
* Match max line size in yaml files with pylint - everywhere 120
characters.
* It looks the "if" condition didn't work. I suspect the ">" didn't
produce a single line. Tested with pyyaml.
* Don't pause a test bc it won't work in GHA anyway - a step must fail
in order to start an SSH session.
