### PR TITLE
Upgrade to cryptography==41.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,19 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-azure-core==1.29.3
+azure-core==1.29.4
     # via
     #   -r requirements.in
     #   azure-storage-blob
-azure-storage-blob==12.17.0
+azure-storage-blob==12.18.1
     # via -r requirements.in
 bcrypt==4.0.1
     # via paramiko
 beautifulsoup4==4.12.2
     # via google
-boto3==1.28.34
+boto3==1.28.53
     # via -r requirements.in
-botocore==1.31.34
+botocore==1.31.53
     # via
     #   boto3
     #   s3transfer
@@ -32,11 +32,11 @@ charset-normalizer==3.2.0
     # via requests
 click==8.1.7
     # via -r requirements.in
-cryptography==41.0.3
+cryptography==41.0.4
     # via
     #   azure-storage-blob
     #   paramiko
-datadog==0.46.0
+datadog==0.47.0
     # via -r requirements.in
 google==3.0.0
     # via -r requirements.in
@@ -44,7 +44,7 @@ google-api-core==2.11.1
     # via
     #   google-cloud-core
     #   google-cloud-storage
-google-auth==2.22.0
+google-auth==2.23.0
     # via
     #   google-api-core
     #   google-cloud-core
@@ -55,7 +55,7 @@ google-cloud-storage==2.3.0
     # via -r requirements.in
 google-crc32c==1.5.0
     # via google-resumable-media
-google-resumable-media==2.5.0
+google-resumable-media==2.6.0
     # via google-cloud-storage
 googleapis-common-protos==1.60.0
     # via google-api-core
@@ -69,7 +69,7 @@ jmespath==1.0.1
     #   botocore
 paramiko==2.12.0
     # via -r requirements.in
-protobuf==4.24.1
+protobuf==4.24.3
     # via
     #   google-api-core
     #   google-cloud-storage
@@ -104,17 +104,16 @@ s3transfer==0.6.2
 six==1.16.0
     # via
     #   azure-core
-    #   google-auth
     #   isodate
     #   paramiko
     #   python-dateutil
-soupsieve==2.4.1
+soupsieve==2.5
     # via beautifulsoup4
 statsd==3.3.0
     # via -r requirements.in
 statsd-tags==3.2.1.post1
     # via -r requirements.in
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   azure-core
     #   azure-storage-blob

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,15 +6,15 @@
 #
 alabaster==0.7.13
     # via sphinx
-astroid==2.15.6
+astroid==2.15.7
     # via pylint
 babel==2.12.1
     # via sphinx
 black==22.12.0
     # via -r requirements_dev.in
-boto3==1.28.34
+boto3==1.28.53
     # via moto
-botocore==1.31.34
+botocore==1.31.53
     # via
     #   boto3
     #   moto
@@ -33,9 +33,9 @@ click==8.1.7
     # via
     #   black
     #   runlike
-coverage[toml]==7.3.0
+coverage[toml]==7.3.1
     # via pytest-cov
-cryptography==41.0.3
+cryptography==41.0.4
     # via moto
 dill==0.3.7
     # via pylint
@@ -75,7 +75,7 @@ mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via -r requirements_dev.in
-moto==4.2.0
+moto==4.2.4
     # via -r requirements_dev.in
 mypy-extensions==1.0.0
     # via black
@@ -91,7 +91,7 @@ platformdirs==3.10.0
     # via
     #   black
     #   pylint
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
 pycodestyle==2.11.0
     # via -r requirements_dev.in
@@ -101,7 +101,7 @@ pygments==2.16.1
     # via sphinx
 pylint==2.17.5
     # via -r requirements_dev.in
-pytest==7.4.0
+pytest==7.4.2
     # via
     #   -r requirements_dev.in
     #   pytest-cov
@@ -158,9 +158,9 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.12.1
     # via pylint
-types-pyyaml==6.0.12.11
+types-pyyaml==6.0.12.12
     # via responses
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   astroid
     #   black
@@ -170,7 +170,7 @@ urllib3==1.26.16
     #   botocore
     #   requests
     #   responses
-websocket-client==1.6.2
+websocket-client==1.6.3
     # via docker
 werkzeug==2.3.7
     # via moto
@@ -180,5 +180,5 @@ xmltodict==0.13.0
     # via moto
 yamllint==1.32.0
     # via -r requirements_dev.in
-zipp==3.16.2
+zipp==3.17.0
     # via importlib-metadata


### PR DESCRIPTION
cryptography is upgraded to fix https://github.com/twindb/backup/security/dependabot/45

and the remaining dependencies brought up to date, too.
